### PR TITLE
Add /database admin page with Solr index backups

### DIFF
--- a/app.js
+++ b/app.js
@@ -149,6 +149,7 @@ app.use('/refs', isLoggedIn, require('./routes/refs'));
 app.use('/sources',   isLoggedIn, require('./routes/sources'));
 app.use('/campaigns', isLoggedIn, require('./routes/campaigns'));
 app.use('/site',      isLoggedIn, require('./routes/site'));
+app.use('/database',     isLoggedIn, superuser, require('./routes/database'));
 app.use('/users',        isLoggedIn, superuser, require('./routes/users'));
 app.use('/users/signup', isLoggedIn, superuser, require('./routes/signup'));
 

--- a/config/solr-backup.js
+++ b/config/solr-backup.js
@@ -1,0 +1,37 @@
+// Cursor-mark exporter for a Solr core. Returns the entire core as a Buffer
+// containing a JSON array of documents — pure function, the caller writes
+// the file. Replaces the standalone tools/exportSolrIndex.py for in-process
+// use; the Python script is kept for ad-hoc CLI exports.
+
+var solr = require('./solr-client');
+var proxyOpts = require('./solr-proxy');
+
+var ROWS_PER_REQUEST = 1000;
+
+async function exportCore(coreName) {
+    var client = solr.createClient({
+        host: proxyOpts.backend.host,
+        port: proxyOpts.backend.port,
+        core: coreName
+    });
+
+    var docs = [];
+    var cursorMark = '*';
+
+    while (true) {
+        // solr-client.get does not re-encode the query string, so cursorMark
+        // (which can contain '+' and '/') must be encoded by us.
+        var query = 'q=*:*&rows=' + ROWS_PER_REQUEST +
+            '&sort=id+asc&cursorMark=' + encodeURIComponent(cursorMark);
+        var obj = await client.get('select', query);
+        var batch = (obj && obj.response && obj.response.docs) || [];
+        docs.push.apply(docs, batch);
+        var next = obj && obj.nextCursorMark;
+        if (!next || next === cursorMark) break;
+        cursorMark = next;
+    }
+
+    return Buffer.from(JSON.stringify(docs), 'utf8');
+}
+
+module.exports = { exportCore: exportCore };

--- a/private/databaseTools.js
+++ b/private/databaseTools.js
@@ -1,0 +1,53 @@
+$(function () {
+    "use strict";
+
+    var base = "https://" + window.location.host;
+
+    $('#createBackupForm').on('submit', function (e) {
+        e.preventDefault();
+        var core = $('#backupCore').val();
+        var $btn = $('#createBackupButton');
+        var $status = $('#backupStatus');
+        $btn.prop('disabled', true);
+        $status.text('Creating backup… this may take a while.');
+
+        $.ajax({
+            url: base + '/database/backup',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ core: core }),
+            success: function (data) {
+                window.location.href = data.redirect || '/database';
+            },
+            error: function (jqXHR) {
+                $btn.prop('disabled', false);
+                var msg = (jqXHR.responseJSON && jqXHR.responseJSON.error) || 'Backup failed.';
+                $status.text(msg);
+            }
+        });
+    });
+
+    var pendingDelete = null;
+
+    $('.delete-backup').on('click', function () {
+        pendingDelete = $(this).data('filename');
+        $('#deleteBackupName').text(pendingDelete);
+        $('#deleteBackupConfirm').modal('show');
+    });
+
+    $('#confirm-delete-backup-button').on('click', function () {
+        if (!pendingDelete) return;
+        var name = pendingDelete;
+        pendingDelete = null;
+        $.ajax({
+            url: base + '/database/backup/' + encodeURIComponent(name),
+            method: 'DELETE',
+            success: function (data) {
+                window.location.href = data.redirect || '/database';
+            },
+            error: function () {
+                window.location.reload(true);
+            }
+        });
+    });
+});

--- a/routes/database.js
+++ b/routes/database.js
@@ -1,0 +1,122 @@
+var express = require('express');
+var router = express.Router();
+var path = require('path');
+var fs = require('fs');
+var log4js = require('log4js');
+var auditLogger = log4js.getLogger('audit');
+var backup = require('../config/solr-backup');
+
+var BACKUP_DIR = path.join(__dirname, '..', 'backups');
+var VALID_CORES = ['rad', 'source'];
+
+// Backup filenames are server-generated; this regex defends DELETE against
+// path traversal and accidental deletion of unrelated files in the dir.
+var FILENAME_RE = /^(rad|source)-\d{8}-\d{6}\.json$/;
+
+function pad(n, w) {
+    var s = String(n);
+    while (s.length < w) s = '0' + s;
+    return s;
+}
+
+function timestamp(d) {
+    return d.getFullYear() +
+        pad(d.getMonth() + 1, 2) +
+        pad(d.getDate(), 2) + '-' +
+        pad(d.getHours(), 2) +
+        pad(d.getMinutes(), 2) +
+        pad(d.getSeconds(), 2);
+}
+
+function formatSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+async function listBackups() {
+    var names;
+    try {
+        names = await fs.promises.readdir(BACKUP_DIR);
+    } catch (err) {
+        if (err.code === 'ENOENT') return [];
+        throw err;
+    }
+    var backups = names.filter(function (n) { return FILENAME_RE.test(n); });
+    var rows = await Promise.all(backups.map(async function (name) {
+        var st = await fs.promises.stat(path.join(BACKUP_DIR, name));
+        var m = name.match(FILENAME_RE);
+        return {
+            name: name,
+            core: m[1],
+            size: st.size,
+            sizeFormatted: formatSize(st.size),
+            mtime: st.mtime.toISOString()
+        };
+    }));
+    rows.sort(function (a, b) { return a.mtime < b.mtime ? 1 : -1; });
+    return rows;
+}
+
+router.get('/', async function (req, res, next) {
+    try {
+        req.replacements.dbActive = 1;
+        req.replacements.backups = await listBackups();
+        res.render('database', req.replacements);
+    } catch (err) {
+        next(err);
+    }
+});
+
+router.post('/backup', async function (req, res, next) {
+    var core = req.body && req.body.core;
+    if (core !== 'rad' && core !== 'source' && core !== 'both') {
+        res.status(400).json({ error: 'Invalid core. Must be rad, source, or both.' });
+        return;
+    }
+
+    var cores = core === 'both' ? VALID_CORES.slice() : [core];
+    var written = [];
+
+    try {
+        await fs.promises.mkdir(BACKUP_DIR, { recursive: true });
+        var ts = timestamp(new Date());
+        for (var i = 0; i < cores.length; i++) {
+            var c = cores[i];
+            var buf = await backup.exportCore(c);
+            var name = c + '-' + ts + '.json';
+            await fs.promises.writeFile(path.join(BACKUP_DIR, name), buf);
+            written.push(name);
+        }
+    } catch (err) {
+        console.log(err);
+        res.status(500).json({ error: 'A problem occurred during backup.' });
+        return;
+    }
+
+    auditLogger.info(req.user.get('email') + ' created backup(s): ' + written.join(', '));
+    req.flash('yay', 'Backup created: ' + written.join(', '));
+    res.json({ redirect: '/database' });
+});
+
+router.delete('/backup/:filename', async function (req, res, next) {
+    var name = req.params.filename;
+    if (!FILENAME_RE.test(name)) {
+        res.status(400).json({ error: 'Invalid backup filename.' });
+        return;
+    }
+
+    try {
+        await fs.promises.unlink(path.join(BACKUP_DIR, name));
+    } catch (err) {
+        console.log(err);
+        res.status(500).json({ error: 'Could not delete backup.' });
+        return;
+    }
+
+    auditLogger.info(req.user.get('email') + ' deleted backup: ' + name);
+    req.flash('yay', 'Backup deleted: ' + name);
+    res.json({ redirect: '/database' });
+});
+
+module.exports = router;

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -1,0 +1,278 @@
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var proxyquire = require('proxyquire').noCallThru();
+var { mockReq, mockRes, mockUser } = require('./helpers');
+
+var fsPromisesStub = {
+    readdir: sinon.stub(),
+    stat: sinon.stub(),
+    mkdir: sinon.stub(),
+    writeFile: sinon.stub(),
+    unlink: sinon.stub()
+};
+var fsStub = { promises: fsPromisesStub };
+
+var backupStub = { exportCore: sinon.stub() };
+
+var auditLoggerStub = { info: sinon.stub() };
+var log4jsStub = { getLogger: sinon.stub().returns(auditLoggerStub) };
+
+var dbRouter = proxyquire('../routes/database', {
+    'fs': fsStub,
+    '../config/solr-backup': backupStub,
+    'log4js': log4jsStub
+});
+
+function findHandler(router, method, path) {
+    var layer = router.stack.find(function (l) {
+        return l.route && l.route.path === path && l.route.methods[method];
+    });
+    if (!layer) throw new Error('No handler for ' + method + ' ' + path);
+    return layer.route.stack[0].handle;
+}
+
+describe('Database Routes', function () {
+
+    beforeEach(function () {
+        fsPromisesStub.readdir.reset();
+        fsPromisesStub.stat.reset();
+        fsPromisesStub.mkdir.reset();
+        fsPromisesStub.writeFile.reset();
+        fsPromisesStub.unlink.reset();
+        backupStub.exportCore.reset();
+        auditLoggerStub.info.reset();
+        fsPromisesStub.mkdir.resolves();
+        fsPromisesStub.writeFile.resolves();
+        fsPromisesStub.unlink.resolves();
+    });
+
+    describe('GET /', function () {
+        it('lists existing backups sorted newest-first with formatted sizes', async function () {
+            fsPromisesStub.readdir.resolves([
+                'rad-20260101-120000.json',
+                'source-20260201-090000.json',
+                'random-other-file.txt'  // should be filtered out
+            ]);
+            fsPromisesStub.stat.callsFake(function (p) {
+                if (p.indexOf('rad-20260101') !== -1) {
+                    return Promise.resolve({ size: 2048, mtime: new Date('2026-01-01T12:00:00Z') });
+                }
+                return Promise.resolve({ size: 1024 * 1024 * 3, mtime: new Date('2026-02-01T09:00:00Z') });
+            });
+
+            var req = mockReq({ replacements: {}, user: mockUser({ permission: 2 }) });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'get', '/')(req, res, next);
+
+            expect(res._rendered).to.equal('database');
+            expect(req.replacements.dbActive).to.equal(1);
+            var rows = req.replacements.backups;
+            expect(rows).to.have.length(2);
+            expect(rows[0].name).to.equal('source-20260201-090000.json');
+            expect(rows[0].core).to.equal('source');
+            expect(rows[0].sizeFormatted).to.equal('3.0 MB');
+            expect(rows[1].name).to.equal('rad-20260101-120000.json');
+            expect(rows[1].core).to.equal('rad');
+            expect(rows[1].sizeFormatted).to.equal('2.0 KB');
+        });
+
+        it('renders an empty list when the backup dir does not exist', async function () {
+            var enoent = new Error('not found');
+            enoent.code = 'ENOENT';
+            fsPromisesStub.readdir.rejects(enoent);
+
+            var req = mockReq({ replacements: {}, user: mockUser({ permission: 2 }) });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'get', '/')(req, res, next);
+
+            expect(res._rendered).to.equal('database');
+            expect(req.replacements.backups).to.deep.equal([]);
+            expect(next.called).to.be.false;
+        });
+
+        it('forwards non-ENOENT errors to next()', async function () {
+            fsPromisesStub.readdir.rejects(new Error('disk on fire'));
+
+            var req = mockReq({ replacements: {}, user: mockUser({ permission: 2 }) });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'get', '/')(req, res, next);
+
+            expect(next.calledOnce).to.be.true;
+            expect(next.firstCall.args[0].message).to.equal('disk on fire');
+        });
+    });
+
+    describe('POST /backup', function () {
+        it('creates a single backup for core=rad', async function () {
+            backupStub.exportCore.resolves(Buffer.from('[]', 'utf8'));
+
+            var req = mockReq({
+                method: 'POST',
+                body: { core: 'rad' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'post', '/backup')(req, res, next);
+
+            expect(backupStub.exportCore.calledOnceWith('rad')).to.be.true;
+            expect(fsPromisesStub.writeFile.calledOnce).to.be.true;
+            var name = require('path').basename(fsPromisesStub.writeFile.firstCall.args[0]);
+            expect(name).to.match(/^rad-\d{8}-\d{6}\.json$/);
+            expect(res._json.redirect).to.equal('/database');
+            expect(auditLoggerStub.info.calledOnce).to.be.true;
+        });
+
+        it('creates two backups for core=both', async function () {
+            backupStub.exportCore.resolves(Buffer.from('[]', 'utf8'));
+
+            var req = mockReq({
+                method: 'POST',
+                body: { core: 'both' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'post', '/backup')(req, res, next);
+
+            expect(backupStub.exportCore.callCount).to.equal(2);
+            expect(backupStub.exportCore.getCall(0).args[0]).to.equal('rad');
+            expect(backupStub.exportCore.getCall(1).args[0]).to.equal('source');
+            expect(fsPromisesStub.writeFile.callCount).to.equal(2);
+        });
+
+        it('rejects an invalid core with 400', async function () {
+            var req = mockReq({
+                method: 'POST',
+                body: { core: 'evil' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'post', '/backup')(req, res, next);
+
+            expect(res.status.calledWith(400)).to.be.true;
+            expect(backupStub.exportCore.called).to.be.false;
+            expect(fsPromisesStub.writeFile.called).to.be.false;
+        });
+
+        it('returns 500 with no audit log when export fails', async function () {
+            backupStub.exportCore.rejects(new Error('Solr down'));
+
+            var req = mockReq({
+                method: 'POST',
+                body: { core: 'rad' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'post', '/backup')(req, res, next);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(fsPromisesStub.writeFile.called).to.be.false;
+            expect(auditLoggerStub.info.called).to.be.false;
+        });
+
+        it('ensures the backup directory exists before writing', async function () {
+            backupStub.exportCore.resolves(Buffer.from('[]', 'utf8'));
+
+            var req = mockReq({
+                method: 'POST',
+                body: { core: 'rad' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'post', '/backup')(req, res, next);
+
+            expect(fsPromisesStub.mkdir.calledOnce).to.be.true;
+            expect(fsPromisesStub.mkdir.firstCall.args[1]).to.deep.equal({ recursive: true });
+        });
+    });
+
+    describe('DELETE /backup/:filename', function () {
+        it('unlinks a valid backup filename', async function () {
+            var req = mockReq({
+                method: 'DELETE',
+                params: { filename: 'rad-20260101-120000.json' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'delete', '/backup/:filename')(req, res, next);
+
+            expect(fsPromisesStub.unlink.calledOnce).to.be.true;
+            var arg = fsPromisesStub.unlink.firstCall.args[0];
+            expect(arg).to.include('rad-20260101-120000.json');
+            expect(res._json.redirect).to.equal('/database');
+            expect(auditLoggerStub.info.calledOnce).to.be.true;
+        });
+
+        it('rejects path traversal attempts with 400', async function () {
+            var req = mockReq({
+                method: 'DELETE',
+                params: { filename: '../package.json' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'delete', '/backup/:filename')(req, res, next);
+
+            expect(res.status.calledWith(400)).to.be.true;
+            expect(fsPromisesStub.unlink.called).to.be.false;
+        });
+
+        it('rejects names not matching the backup pattern', async function () {
+            var req = mockReq({
+                method: 'DELETE',
+                params: { filename: 'random.json' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'delete', '/backup/:filename')(req, res, next);
+
+            expect(res.status.calledWith(400)).to.be.true;
+            expect(fsPromisesStub.unlink.called).to.be.false;
+        });
+
+        it('returns 500 when unlink fails', async function () {
+            fsPromisesStub.unlink.rejects(new Error('permission denied'));
+            var req = mockReq({
+                method: 'DELETE',
+                params: { filename: 'rad-20260101-120000.json' },
+                user: mockUser({ permission: 2 }),
+                flash: sinon.stub()
+            });
+            var res = mockRes();
+            var next = sinon.spy();
+
+            await findHandler(dbRouter, 'delete', '/backup/:filename')(req, res, next);
+
+            expect(res.status.calledWith(500)).to.be.true;
+            expect(auditLoggerStub.info.called).to.be.false;
+        });
+    });
+});

--- a/test/solr-backup.test.js
+++ b/test/solr-backup.test.js
@@ -1,0 +1,112 @@
+var expect = require('chai').expect;
+var sinon = require('sinon');
+var proxyquire = require('proxyquire').noCallThru();
+
+var solrClientStub, solrProxyStub, backup;
+
+function load() {
+    return proxyquire('../config/solr-backup', {
+        './solr-client': solrClientStub,
+        './solr-proxy': solrProxyStub
+    });
+}
+
+describe('config/solr-backup', function () {
+
+    var clientStub;
+
+    beforeEach(function () {
+        clientStub = { get: sinon.stub() };
+        solrClientStub = { createClient: sinon.stub().returns(clientStub) };
+        solrProxyStub = { backend: { host: 'localhost', port: 8983 } };
+        backup = load();
+    });
+
+    describe('exportCore(coreName)', function () {
+        it('creates a client for the requested core with proxy backend coords', async function () {
+            clientStub.get.resolves({ response: { docs: [] }, nextCursorMark: '*' });
+            await backup.exportCore('rad');
+            expect(solrClientStub.createClient.calledOnce).to.be.true;
+            var opts = solrClientStub.createClient.firstCall.args[0];
+            expect(opts).to.deep.equal({ host: 'localhost', port: 8983, core: 'rad' });
+        });
+
+        it('terminates when nextCursorMark equals the previous mark', async function () {
+            clientStub.get.resolves({
+                response: { docs: [{ id: 1 }, { id: 2 }] },
+                nextCursorMark: '*'
+            });
+            var buf = await backup.exportCore('rad');
+            expect(clientStub.get.callCount).to.equal(1);
+            expect(JSON.parse(buf.toString('utf8'))).to.deep.equal([{ id: 1 }, { id: 2 }]);
+        });
+
+        it('concatenates docs across multiple pages until cursor stabilizes', async function () {
+            clientStub.get.onCall(0).resolves({
+                response: { docs: [{ id: 1 }, { id: 2 }] },
+                nextCursorMark: 'AoEpMQ=='
+            });
+            clientStub.get.onCall(1).resolves({
+                response: { docs: [{ id: 3 }, { id: 4 }] },
+                nextCursorMark: 'AoEpMw=='
+            });
+            clientStub.get.onCall(2).resolves({
+                response: { docs: [{ id: 5 }] },
+                nextCursorMark: 'AoEpMw=='
+            });
+            var buf = await backup.exportCore('rad');
+            expect(clientStub.get.callCount).to.equal(3);
+            expect(JSON.parse(buf.toString('utf8'))).to.deep.equal([
+                { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }
+            ]);
+        });
+
+        it('passes the cursorMark URL-encoded on each subsequent request', async function () {
+            // nextCursorMark from Solr is base64; can contain '+' and '/'
+            // which need encoding before going on the query string.
+            clientStub.get.onCall(0).resolves({
+                response: { docs: [{ id: 1 }] },
+                nextCursorMark: 'AoE+/Q=='
+            });
+            clientStub.get.onCall(1).resolves({
+                response: { docs: [] },
+                nextCursorMark: 'AoE+/Q=='
+            });
+            await backup.exportCore('rad');
+            var firstQuery = clientStub.get.getCall(0).args[1];
+            var secondQuery = clientStub.get.getCall(1).args[1];
+            expect(firstQuery).to.include('cursorMark=' + encodeURIComponent('*'));
+            expect(secondQuery).to.include('cursorMark=' + encodeURIComponent('AoE+/Q=='));
+            // Sanity: '+' and '/' are not raw in the encoded query.
+            expect(secondQuery).to.not.include('+/Q==');
+        });
+
+        it('hits the /select handler with q=*:* and id-asc sort', async function () {
+            clientStub.get.resolves({ response: { docs: [] }, nextCursorMark: '*' });
+            await backup.exportCore('source');
+            var route = clientStub.get.firstCall.args[0];
+            var query = clientStub.get.firstCall.args[1];
+            expect(route).to.equal('select');
+            expect(query).to.include('q=*:*');
+            expect(query).to.include('sort=id+asc');
+            expect(query).to.include('rows=1000');
+        });
+
+        it('rejects when the underlying solr-client request fails', async function () {
+            clientStub.get.rejects(new Error('connect refused'));
+            try {
+                await backup.exportCore('rad');
+                throw new Error('expected rejection');
+            } catch (err) {
+                expect(err.message).to.equal('connect refused');
+            }
+        });
+
+        it('returns an empty JSON array when the core has no docs', async function () {
+            clientStub.get.resolves({ response: { docs: [] }, nextCursorMark: '*' });
+            var buf = await backup.exportCore('rad');
+            expect(buf).to.be.instanceOf(Buffer);
+            expect(JSON.parse(buf.toString('utf8'))).to.deep.equal([]);
+        });
+    });
+});

--- a/views/database.hbs
+++ b/views/database.hbs
@@ -1,0 +1,93 @@
+{{!-- Database admin page: Solr index backups (and future backend tools) --}}
+{{#> layout title="Database" nav=1 dbActive=1}}
+
+{{#*inline "header-block"}}
+    <style>
+        .table td.fit,
+        .table th.fit {
+            white-space: nowrap;
+            width: 1%;
+        }
+    </style>
+{{/inline}}
+
+{{#*inline "search-area"}}
+<form class="form inline" id="createBackupForm">
+    <div class="form-group">
+        <label for="backupCore">Backup core:</label>
+        <select class="form-control" id="backupCore" name="core">
+            <option value="rad">References (rad)</option>
+            <option value="source">Sources (source)</option>
+            <option value="both">Both</option>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-primary" id="createBackupButton">
+        <span class="glyphicon glyphicon-floppy-disk"></span> Create Backup
+    </button>
+    <span id="backupStatus" class="text-muted" style="margin-left: 1em;"></span>
+</form>
+{{/inline}}
+
+{{#*inline "results-area"}}
+<div id="mainDisplay" role="main">
+    <div class="table-responsive">
+        <table class="table table-sm table-hover">
+            <thead>
+                <tr>
+                    <th>Filename</th>
+                    <th class="fit">Core</th>
+                    <th class="fit">Created</th>
+                    <th class="fit">Size</th>
+                    <th class="fit">Delete</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{#each backups}}
+                <tr>
+                    <td>{{name}}</td>
+                    <td class="fit">{{core}}</td>
+                    <td class="fit">{{mtime}}</td>
+                    <td class="fit">{{sizeFormatted}}</td>
+                    <td class="fit">
+                        <a class="btn btn-default delete-backup" data-filename="{{name}}" title="Delete backup">
+                            <span class="glyphicon glyphicon-trash"></span>
+                        </a>
+                    </td>
+                </tr>
+                {{/each}}
+                {{#unless backups.length}}
+                <tr>
+                    <td colspan="5" class="text-muted text-center">No backups yet. Use the form above to create one.</td>
+                </tr>
+                {{/unless}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{/inline}}
+
+{{#*inline "modal-block"}}
+<div class="modal fade" id="deleteBackupConfirm" role="dialog" tabindex=0>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="close">&times;</button>
+                <h4 class="modal-title">Delete this backup?</h4>
+            </div>
+            <div class="modal-body">
+                <p>About to delete <strong id="deleteBackupName"></strong>. This cannot be undone.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger" data-dismiss="modal" id="confirm-delete-backup-button">Delete</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>
+{{/inline}}
+
+{{#*inline "scripts-block"}}
+<script nonce="{{nonce}}" src="private/databaseTools.js"></script>
+{{/inline}}
+
+{{/layout}}

--- a/views/partials/navbar.hbs
+++ b/views/partials/navbar.hbs
@@ -20,6 +20,7 @@
         <li {{#if srcActive}}class="active"{{/if}}><a href="/sources">Sources</a></li>
         <li {{#if cmpActive}}class="active"{{/if}}><a href="/campaigns">Campaigns</a></li>
         <li {{#if sitActive}}class="active"{{/if}}><a href="/site">Website</a></li>
+        {{#if users}}<li {{#if dbActive}}class="active"{{/if}}><a href="/database">Database</a></li>{{/if}}
         {{#if users}}<li {{#if useActive}}class="active"{{/if}}><a href="/users">Users</a></li>{{/if}}
       </ul>
       <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Adds a superuser-only /database page (between Website and Users) that lists, creates, and deletes Solr index backups. New config/solr-backup.js exports cores via cursor-mark and returns a JSON Buffer; routes/database.js owns the filesystem (./backups/, auto-created) and validates DELETE filenames against ^(rad|source)-\d{8}-\d{6}\.json$ to block path traversal. Restore remains a sysadmin task and is out of scope. tools/exportSolrIndex.py is left in place for CLI use. #64 